### PR TITLE
Making the batch re-ordering phase determinstic for parity testing

### DIFF
--- a/pykilosort/cluster.py
+++ b/pykilosort/cluster.py
@@ -222,6 +222,7 @@ def initializeWdata2(call, uprojDAT, Nchan, nPCs, Nfilt, iC):
     # pick random spikes from the sample
     # WARNING: replace ceil by floor because this is a random index, and 0/1 indexing
     # discrepancy between Python and MATLAB.
+    np.random.seed(42)
     irand = np.floor(np.random.rand(Nfilt) * uprojDAT.shape[1]).astype(np.int32)
 
     W = cp.zeros((nPCs, Nchan, Nfilt), dtype=np.float32)


### PR DESCRIPTION
Some functions in the batch re-ordering phase do not give reproducible outputs. As I work on this for parity testing with the Matlab version I'll update my code here